### PR TITLE
optimized memory and cpu fetching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wextra -O3 -Wno-unused-result -Wno-unused-parameter
+CFLAGS = -Wall -Wextra -O3 -Wno-unused-result -Wno-unused-parameter -masm=intel
 TARGET = puppyfetch
 SRC = puppyfetch.c
 PREFIX = /usr/bin

--- a/puppyfetch.c
+++ b/puppyfetch.c
@@ -274,7 +274,7 @@ void get_cpuinfo_cpuid(char *buf) {
       "mov [rdi+36], ebx\n"
       "mov [rdi+40], ecx\n"
       "mov [rdi+44], edx\n"
-      : "=rdi" (buf)
+      : "=D" (buf)
       :
       : "eax", "ebx", "ecx", "edx"
     );


### PR DESCRIPTION
optimize cpu information fetching for x86 by using cpuid eax = 0x80000000 if it is supported
optimize memory information fetching and make it support more platforms by just using sysconf